### PR TITLE
Add_npcs

### DIFF
--- a/src/main/java/com/suracki/residentmystery/controller/AdminController.java
+++ b/src/main/java/com/suracki/residentmystery/controller/AdminController.java
@@ -401,4 +401,64 @@ public class AdminController {
         }
         return adminService.updateEnding(id, ending, result, model);
     }
+
+    @GetMapping("/admin/addNpc")
+    public String addNpc(Model model, Npc npc)
+    {
+        logger.info("User connected to /admin/addNpc endpoint");
+        if (!roleCheck.RoleCheck("Admin")) {
+            logger.info("User is not an ADMIN, logging out and redirecting");
+            SecurityContextHolder.getContext().getAuthentication().setAuthenticated(false);
+            return "redirect:/";
+        }
+        return adminService.addNpc(model, npc);
+    }
+
+    @PostMapping("/admin/addNpc/validate")
+    public String addEndingNpc(Model model, @Valid Npc npc, BindingResult result)
+    {
+        logger.info("User connected to /admin/addNpc/validate endpoint");
+        if (!roleCheck.RoleCheck("Admin")) {
+            logger.info("User is not an ADMIN, logging out and redirecting");
+            SecurityContextHolder.getContext().getAuthentication().setAuthenticated(false);
+            return "redirect:/";
+        }
+        return adminService.validateNpc(model, result, npc);
+    }
+
+    @GetMapping("/admin/deleteNpc/{id}")
+    public String deleteNpc(@PathVariable("id") Integer id, Model model) {
+        logger.info("User connected to admin/deleteNpc endpoint for npc with id " + id);
+        if (!roleCheck.RoleCheck("Admin")) {
+            logger.info("User is not an ADMIN, logging out and redirecting");
+            SecurityContextHolder.getContext().getAuthentication().setAuthenticated(false);
+            return "redirect:/";
+        }
+        return adminService.deleteNpc(id, model);
+    }
+
+    @GetMapping("/admin/updateNpc/{id}")
+    public String updateNpc(@PathVariable("id") Integer id, Model model)
+    {
+        logger.info("User connected to admin/updateNpc endpoint for npc with id " + id);
+        if (!roleCheck.RoleCheck("Admin")) {
+            logger.info("User is not an ADMIN, logging out and redirecting");
+            SecurityContextHolder.getContext().getAuthentication().setAuthenticated(false);
+            return "redirect:/";
+        }
+        return adminService.updateNpc(id, model);
+    }
+
+    @PostMapping("/admin/updateNpc/{id}")
+    public String updateNpc(@PathVariable("id") Integer id, Model model,
+                               @Valid Npc npc, BindingResult result)
+    {
+        logger.info("User connected to admin/updateNpc POST endpoint for npc with id " + id);
+        if (!roleCheck.RoleCheck("Admin")) {
+            logger.info("User is not an ADMIN, logging out and redirecting");
+            SecurityContextHolder.getContext().getAuthentication().setAuthenticated(false);
+            return "redirect:/";
+        }
+        return adminService.updateNpc(id, npc, result, model);
+    }
 }

--- a/src/main/java/com/suracki/residentmystery/controller/GameController.java
+++ b/src/main/java/com/suracki/residentmystery/controller/GameController.java
@@ -63,5 +63,12 @@ public class GameController {
         return gameService.restart(model);
     }
 
+    @GetMapping("/game/speakWith")
+    public String speak(@RequestParam(value="npc") String npcName, Model model)
+    {
+        logger.info("User connected to /game/interactWith/ endpoint");
+        return gameService.speak(model, npcName);
+    }
+
 
 }

--- a/src/main/java/com/suracki/residentmystery/domain/Interactable.java
+++ b/src/main/java/com/suracki/residentmystery/domain/Interactable.java
@@ -29,6 +29,8 @@ public class Interactable {
 
     private boolean locked;
 
+    private boolean consumeKey;
+
     private boolean gameEnd;
 
     private String endName;
@@ -145,5 +147,17 @@ public class Interactable {
 
     public void setEndName(String endName) {
         this.endName = endName;
+    }
+
+    public boolean doesConsumeKey() {
+        return consumeKey;
+    }
+
+    public void setConsumeKey(boolean consumeKey) {
+        this.consumeKey = consumeKey;
+    }
+
+    public boolean isConsumeKey() {
+        return consumeKey;
     }
 }

--- a/src/main/java/com/suracki/residentmystery/domain/Npc.java
+++ b/src/main/java/com/suracki/residentmystery/domain/Npc.java
@@ -1,0 +1,158 @@
+package com.suracki.residentmystery.domain;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotEmpty;
+
+@Entity
+@Table(name = "npcs")
+public class Npc {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.AUTO)
+    private Integer id;
+
+    @NotEmpty(message = "NPC name is mandatory.")
+    private String npcName;
+
+    @NotEmpty(message = "NPC description is mandatory.")
+    private String npcDesc;
+
+    @NotEmpty(message = "Enter name of room NPC starts in.")
+    private String roomName;
+
+    private boolean canWander;
+
+    @NotEmpty(message = "First interaction text is mandatory.")
+    private String firstInteraction;
+
+    @NotEmpty(message = "Repeat interaction text is mandatory.")
+    private String repeatInteraction;
+
+    @NotEmpty(message = "Solving interaction text is mandatory.")
+    private String solvingInteraction;
+
+    @NotEmpty(message = "Aleady solved interaction text is mandatory.")
+    private String alreadySolvedInteraction;
+
+    private String rewardLoot;
+
+    private boolean locked;
+
+    private String keyName;
+
+    private boolean gameEnd;
+
+    private String endName;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getNpcName() {
+        return npcName;
+    }
+
+    public void setNpcName(String npcName) {
+        this.npcName = npcName;
+    }
+
+    public String getNpcDesc() {
+        return npcDesc;
+    }
+
+    public void setNpcDesc(String npcDesc) {
+        this.npcDesc = npcDesc;
+    }
+
+    public String getRoomName() {
+        return roomName;
+    }
+
+    public void setRoomName(String roomName) {
+        this.roomName = roomName;
+    }
+
+    public boolean isCanWander() {
+        return canWander;
+    }
+
+    public void setCanWander(boolean canWander) {
+        this.canWander = canWander;
+    }
+
+    public String getFirstInteraction() {
+        return firstInteraction;
+    }
+
+    public void setFirstInteraction(String firstInteraction) {
+        this.firstInteraction = firstInteraction;
+    }
+
+    public String getRepeatInteraction() {
+        return repeatInteraction;
+    }
+
+    public void setRepeatInteraction(String repeatInteraction) {
+        this.repeatInteraction = repeatInteraction;
+    }
+
+    public String getSolvingInteraction() {
+        return solvingInteraction;
+    }
+
+    public void setSolvingInteraction(String solvingInteraction) {
+        this.solvingInteraction = solvingInteraction;
+    }
+
+    public String getAlreadySolvedInteraction() {
+        return alreadySolvedInteraction;
+    }
+
+    public void setAlreadySolvedInteraction(String alreadySolvedInteraction) {
+        this.alreadySolvedInteraction = alreadySolvedInteraction;
+    }
+
+    public String getRewardLoot() {
+        return rewardLoot;
+    }
+
+    public void setRewardLoot(String rewardLoot) {
+        this.rewardLoot = rewardLoot;
+    }
+
+    public boolean isLocked() {
+        return locked;
+    }
+
+    public void setLocked(boolean locked) {
+        this.locked = locked;
+    }
+
+    public String getKeyName() {
+        return keyName;
+    }
+
+    public void setKeyName(String keyName) {
+        this.keyName = keyName;
+    }
+
+    public boolean isGameEnd() {
+        return gameEnd;
+    }
+
+    public void setGameEnd(boolean gameEnd) {
+        this.gameEnd = gameEnd;
+    }
+
+    public String getEndName() {
+        return endName;
+    }
+
+    public void setEndName(String endName) {
+        this.endName = endName;
+    }
+}

--- a/src/main/java/com/suracki/residentmystery/domain/Npc.java
+++ b/src/main/java/com/suracki/residentmystery/domain/Npc.java
@@ -42,6 +42,8 @@ public class Npc {
 
     private String keyName;
 
+    private boolean consumeKey;
+
     private boolean gameEnd;
 
     private String endName;
@@ -164,5 +166,17 @@ public class Npc {
 
     public void setWanderChance(int wanderChance) {
         this.wanderChance = wanderChance;
+    }
+
+    public boolean doesConsumeKey() {
+        return consumeKey;
+    }
+
+    public void setConsumeKey(boolean consumeKey) {
+        this.consumeKey = consumeKey;
+    }
+
+    public boolean isConsumeKey() {
+        return consumeKey;
     }
 }

--- a/src/main/java/com/suracki/residentmystery/domain/Npc.java
+++ b/src/main/java/com/suracki/residentmystery/domain/Npc.java
@@ -22,6 +22,8 @@ public class Npc {
 
     private boolean canWander;
 
+    private int wanderChance;
+
     @NotEmpty(message = "First interaction text is mandatory.")
     private String firstInteraction;
 
@@ -154,5 +156,13 @@ public class Npc {
 
     public void setEndName(String endName) {
         this.endName = endName;
+    }
+
+    public int getWanderChance() {
+        return wanderChance;
+    }
+
+    public void setWanderChance(int wanderChance) {
+        this.wanderChance = wanderChance;
     }
 }

--- a/src/main/java/com/suracki/residentmystery/domain/temporary/GameData.java
+++ b/src/main/java/com/suracki/residentmystery/domain/temporary/GameData.java
@@ -11,6 +11,7 @@ public class GameData {
     List<Loot> loots;
     List<ExitMapping> exitMappings;
     List<Ending> endings;
+    List<Npc> npcs;
 
     public List<Room> getRooms() {
         return rooms;
@@ -50,5 +51,13 @@ public class GameData {
 
     public void setEndings(List<Ending> endings) {
         this.endings = endings;
+    }
+
+    public List<Npc> getNpcs() {
+        return npcs;
+    }
+
+    public void setNpcs(List<Npc> npcs) {
+        this.npcs = npcs;
     }
 }

--- a/src/main/java/com/suracki/residentmystery/domain/temporary/GameState.java
+++ b/src/main/java/com/suracki/residentmystery/domain/temporary/GameState.java
@@ -8,6 +8,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 public class GameState {
 
@@ -243,5 +244,52 @@ public class GameState {
             }
         }
         return false;
+    }
+
+    public void moveWanderingNpcs() {
+        logger.info("moveWanderingNpcs called");
+        for (Npc npc : npcs) {
+            Random rand = new Random();
+            if (npc.isCanWander()) {
+                logger.info("Wandering NPC found: " + npc.getNpcName());
+                Room startLocation = findRoom(npc.getRoomName());
+                List<ExitMapping> exits = findExitMappingByRoomname(npc.getRoomName());
+                for (ExitMapping exit : exits) {
+                    Interactable door = findInteractable(exit.getExitName());
+                    if (!door.isLocked() && !door.isGameEnd()) {
+                        int random = rand.nextInt(100);
+                        if (random < npc.getWanderChance()) {
+                            logger.info("Random: " + random + ", NPC wandering...");
+
+                            List<ExitMapping> exitMappings = exits;
+                            List<String> exitsNames = new ArrayList<>();
+                            List<String> exitDirections = new ArrayList<>();
+                            for (ExitMapping mapping : exitMappings) {
+                                exitsNames.add(mapping.getExitName());
+                                exitDirections.add(mapping.getExitDirection());
+                            }
+
+                            String exitDirection = exitDirections.get(exitsNames.indexOf(exit.getExitName()));
+                            String roomName = "";
+                            List<ExitMapping> allExitMappings = getExitMappings();
+                            for (ExitMapping mapping : allExitMappings) {
+                                if (mapping.getExitName().equals(exit.getExitName()) && !mapping.getExitDirection().equals(exitDirection)) {
+                                    logger.info("NPC moving from " + npc.getRoomName() + " to " + mapping.getRoomName());
+                                    npc.setRoomName(mapping.getRoomName());
+                                }
+                            }
+
+                            return;
+
+                        }
+                        else {
+                            logger.info("Random: " + random + ", NPC not moving.");
+                        }
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/src/main/java/com/suracki/residentmystery/domain/temporary/GameState.java
+++ b/src/main/java/com/suracki/residentmystery/domain/temporary/GameState.java
@@ -19,6 +19,7 @@ public class GameState {
     private List<Ending> endings;
     private String currentRoom;
     private List<String> currentLoot;
+    private List<String> spokenToNpcs;
     private LocalDateTime startTime;
 
     private static final Logger logger = LogManager.getLogger(GameState.class);
@@ -216,5 +217,31 @@ public class GameState {
             }
         }
         return null;
+    }
+
+    public Npc findNpc(String npcName) {
+        for (Npc npc : npcs) {
+            if (npc.getNpcName().equals(npcName)) {
+                return npc;
+            }
+        }
+        return null;
+    }
+
+    public List<String> getSpokenToNpcs() {
+        return spokenToNpcs;
+    }
+
+    public void setSpokenToNpcs(List<String> spokenToNpcs) {
+        this.spokenToNpcs = spokenToNpcs;
+    }
+
+    public boolean hasSpokenTo(String npcName) {
+        for (String npc : spokenToNpcs) {
+            if (npc.equals(npcName)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/suracki/residentmystery/domain/temporary/GameState.java
+++ b/src/main/java/com/suracki/residentmystery/domain/temporary/GameState.java
@@ -237,6 +237,10 @@ public class GameState {
         this.spokenToNpcs = spokenToNpcs;
     }
 
+    public void addSpokenToNpc(String npcName) {
+        spokenToNpcs.add(npcName);
+    }
+
     public boolean hasSpokenTo(String npcName) {
         for (String npc : spokenToNpcs) {
             if (npc.equals(npcName)) {

--- a/src/main/java/com/suracki/residentmystery/domain/temporary/GameState.java
+++ b/src/main/java/com/suracki/residentmystery/domain/temporary/GameState.java
@@ -1,12 +1,12 @@
 package com.suracki.residentmystery.domain.temporary;
 
-import com.suracki.residentmystery.domain.Interactable;
-import com.suracki.residentmystery.domain.Loot;
-import com.suracki.residentmystery.domain.Room;
+import com.suracki.residentmystery.domain.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import javax.persistence.criteria.CriteriaBuilder;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 public class GameState {
@@ -14,6 +14,9 @@ public class GameState {
     private List<Room> rooms;
     private List<Loot> loots;
     private List<Interactable> interactables;
+    private List<Npc> npcs;
+    private List<ExitMapping> exitMappings;
+    private List<Ending> endings;
     private String currentRoom;
     private List<String> currentLoot;
     private LocalDateTime startTime;
@@ -25,6 +28,7 @@ public class GameState {
         logger.info(rooms.size() + " rooms.");
         logger.info(loots.size() + " loots.");
         logger.info(interactables.size() + " interactables.");
+        logger.info(npcs.size() + " npcs.");
         logger.info(currentRoom + " as current room.");
         logger.info(currentLoot + " as current loot.");
     }
@@ -119,5 +123,98 @@ public class GameState {
 
     public void setStartTime(LocalDateTime startTime) {
         this.startTime = startTime;
+    }
+
+    public List<Npc> getNpcs() {
+        return npcs;
+    }
+
+    public void setNpcs(List<Npc> npcs) {
+        this.npcs = npcs;
+    }
+
+    public Room findStartingRoom() {
+        for (Room room : rooms) {
+            if (room.isStartRoom()) {
+                return room;
+            }
+        }
+        return rooms.get(0);
+    }
+
+    public List<ExitMapping> getExitMappings() {
+        return exitMappings;
+    }
+
+    public void setExitMappings(List<ExitMapping> exitMappings) {
+        this.exitMappings = exitMappings;
+    }
+
+    public List<ExitMapping> findExitMappingByRoomname(String roomName) {
+        List<ExitMapping> roomExits = new ArrayList<>();
+        for (ExitMapping exitMapping : exitMappings) {
+            if (exitMapping.getRoomName().equals(roomName)) {
+                roomExits.add(exitMapping);
+            }
+        }
+        return roomExits;
+    }
+
+    public List<Loot> findLootByRoomname(String roomName) {
+        List<Loot> roomLoot = new ArrayList<>();
+        for (Loot loot : loots) {
+            if (loot.getRoomName() != null ) {
+                if (loot.getRoomName().equals(roomName)) {
+                    roomLoot.add(loot);
+                }
+            }
+        }
+        return roomLoot;
+    }
+
+    public List<Interactable> findInteractablesByRoomname(String roomName) {
+        List<Interactable> roomInters = new ArrayList<>();
+        for (Interactable interactable : interactables) {
+            if (interactable.getRoomName().equals(roomName)) {
+                roomInters.add(interactable);
+            }
+        }
+        return roomInters;
+    }
+
+    public List<Npc> findNpcsByRoomname(String roomName) {
+        List<Npc> roomNpcs = new ArrayList<>();
+        for (Npc npc : npcs) {
+            if (npc.getRoomName().equals(roomName)) {
+                roomNpcs.add(npc);
+            }
+        }
+        return roomNpcs;
+    }
+
+    public Interactable findInteractableByName(String interactableName) {
+        for (Interactable interactable : interactables) {
+            if (interactable.getInteractableName().equals(interactableName)) {
+                return interactable;
+            }
+        }
+        return null;
+    }
+
+    public List<Ending> getEndings() {
+        return endings;
+    }
+
+    public void setEndings(List<Ending> endings) {
+        this.endings = endings;
+    }
+
+    public Ending findEndingByName(String endingName) {
+        for (Ending ending : endings) {
+            if (ending.getEndingName().equals(endingName)) {
+                return ending;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/suracki/residentmystery/repository/NpcRepository.java
+++ b/src/main/java/com/suracki/residentmystery/repository/NpcRepository.java
@@ -1,0 +1,15 @@
+package com.suracki.residentmystery.repository;
+
+import com.suracki.residentmystery.domain.Interactable;
+import com.suracki.residentmystery.domain.Npc;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface NpcRepository extends JpaRepository<Npc, Integer> {
+
+    @Query("SELECT u FROM Npc u WHERE u.roomName = ?1")
+    List<Npc> findByRoomname(String roomName);
+
+}

--- a/src/main/resources/templates/admin/gui/addInter.html
+++ b/src/main/resources/templates/admin/gui/addInter.html
@@ -69,6 +69,12 @@
                 </div>
             </div>
             <div class="form-group">
+                <label for="consumeKey" class="col-sm-2 control-label">Consumes Key?</label>
+                <div class="col-sm-10">
+                    <input type="checkbox" th:field="*{consumeKey}" id="consumeKey" value="no">
+                </div>
+            </div>
+            <div class="form-group">
                 <label for="roomName" class="col-sm-2 control-label">Location (Room Name)</label>
                 <div class="col-sm-10">
                     <input type="text" th:field="*{roomName}" id="roomName" placeholder="roomName" class="col-4">

--- a/src/main/resources/templates/admin/gui/addNpc.html
+++ b/src/main/resources/templates/admin/gui/addNpc.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title> Resident Mystery </title>
+    <link rel="stylesheet" th:href="@{/css/bootstrap.min.css}" >
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link rel="stylesheet" th:href="@{https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css}">
+</head>
+<body>
+<div class="container-collector" id="main">
+    <div class="container-content" id="content_flex_top_collector">
+        <div class="col-6">
+
+        </div>
+
+        <div class="col-6 text-right">
+            Logged in user: <b th:inline="text"  class="user"> [[${#httpServletRequest.remoteUser}]] </b>
+            <form th:action="@{/app-logout}" method="POST" name="logoutForm">
+                <input type="submit" value="Logout"/>
+            </form>
+        </div>
+    </div>
+
+
+
+
+    <div class="container-content" id="content_flex_center">
+        <form action="#" th:action="@{/admin/addNpc/validate}" th:object="${npc}" method="post" class="form-horizontal" style="width: 100%">
+            <div class="form-group">
+                <label for="npcName" class="col-sm-2 control-label">Name</label>
+                <div class="col-sm-10">
+                    <input type="text" th:field="*{npcName}" id="npcName" placeholder="npcName" class="col-4">
+                    <p class="text-danger" th:if="${#fields.hasErrors('npcName')}" th:errors="*{npcName}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="npcDesc" class="col-sm-2 control-label">Description</label>
+                <div class="col-sm-10">
+                    <textarea class="form-control" id="npcDesc" rows="20" th:field="*{npcDesc}"></textarea>
+                    <p class="text-danger" th:if="${#fields.hasErrors('npcDesc')}" th:errors="*{npcDesc}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="roomName" class="col-sm-2 control-label">Location (Room Name)</label>
+                <div class="col-sm-10">
+                    <input type="text" th:field="*{roomName}" id="roomName" placeholder="roomName" class="col-4">
+                    <p class="text-danger" th:if="${#fields.hasErrors('roomName')}" th:errors="*{roomName}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="canWander" class="col-sm-2 control-label">Can Wander?</label>
+                <div class="col-sm-10">
+                    <input type="checkbox" th:field="*{canWander}" id="canWander" value="yes">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="wanderChance" class="col-sm-2 control-label">Chance to wander (0-100)</label>
+                <div class="col-sm-10">
+                    <input type="text" th:field="*{wanderChance}" id="wanderChance" placeholder="wanderChance" class="col-4">
+                    <p class="text-danger" th:if="${#fields.hasErrors('wanderChance')}" th:errors="*{wanderChance}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="firstInteraction" class="col-sm-2 control-label">First Interaction</label>
+                <div class="col-sm-10">
+                    <textarea class="form-control" id="firstInteraction" rows="5" th:field="*{firstInteraction}"></textarea>
+                    <p class="text-danger" th:if="${#fields.hasErrors('firstInteraction')}" th:errors="*{firstInteraction}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="repeatInteraction" class="col-sm-2 control-label">Repeat Interaction</label>
+                <div class="col-sm-10">
+                    <textarea class="form-control" id="repeatInteraction" rows="5" th:field="*{repeatInteraction}"></textarea>
+                    <p class="text-danger" th:if="${#fields.hasErrors('repeatInteraction')}" th:errors="*{repeatInteraction}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="solvingInteraction" class="col-sm-2 control-label">Solving Interaction</label>
+                <div class="col-sm-10">
+                    <textarea class="form-control" id="solvingInteraction" rows="5" th:field="*{solvingInteraction}"></textarea>
+                    <p class="text-danger" th:if="${#fields.hasErrors('solvingInteraction')}" th:errors="*{solvingInteraction}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="alreadySolvedInteraction" class="col-sm-2 control-label">Already Solved Interaction</label>
+                <div class="col-sm-10">
+                    <textarea class="form-control" id="alreadySolvedInteraction" rows="5" th:field="*{alreadySolvedInteraction}"></textarea>
+                    <p class="text-danger" th:if="${#fields.hasErrors('alreadySolvedInteraction')}" th:errors="*{alreadySolvedInteraction}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="rewardLoot" class="col-sm-2 control-label">Reward (Loot Name)</label>
+                <div class="col-sm-10">
+                    <input type="text" th:field="*{rewardLoot}" id="rewardLoot" placeholder="rewardLoot" class="col-4">
+                    <p class="text-danger" th:if="${#fields.hasErrors('rewardLoot')}" th:errors="*{rewardLoot}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="locked" class="col-sm-2 control-label">Has Quest/Locked?</label>
+                <div class="col-sm-10">
+                    <input type="checkbox" th:field="*{locked}" id="locked" value="yes">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="keyName" class="col-sm-2 control-label">Quest/Key Item (Loot Name)</label>
+                <div class="col-sm-10">
+                    <input type="text" th:field="*{keyName}" id="keyName" placeholder="keyName" class="col-4">
+                    <p class="text-danger" th:if="${#fields.hasErrors('rewardLoot')}" th:errors="*{keyName}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="consumeKey" class="col-sm-2 control-label">Consumes Key?</label>
+                <div class="col-sm-10">
+                    <input type="checkbox" th:field="*{consumeKey}" id="consumeKey" value="no">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="gameEnd" class="col-sm-2 control-label">End Game When Solved?</label>
+                <div class="col-sm-10">
+                    <input type="checkbox" th:field="*{gameEnd}" id="gameEnd" value="yes">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="endName" class="col-sm-2 control-label">Ending Name</label>
+                <div class="col-sm-10">
+                    <input type="text" th:field="*{endName}" id="endName" placeholder="endName" class="col-4">
+                    <p class="text-danger" th:if="${#fields.hasErrors('endName')}" th:errors="*{endName}"></p>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <div class="col-sm-12">
+                    <a class="btn btn-danger btn-sm" href="/admin/manage">Cancel</a>
+                    <input class="btn btn-primary btn-sm" type="submit" value="Add Npc">
+                </div>
+            </div>
+
+        </form>
+    </div>
+
+    <div id="btmL">
+        <h2>Find me on social media</h2>
+        <h3><strong>A new project idea?</strong> Contact me!</h3>
+        <a href="https://twitter.com/Suracki" class="fa fa-twitter"></a>
+        <a href="https://github.com/Suracki" class="fa fa-github"></a>
+        <a href="https://www.linkedin.com/in/simon-linford/" class="fa fa-linkedin"></a>
+    </div>
+    <div id="btmR"></div>
+
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/gui/editInter.html
+++ b/src/main/resources/templates/admin/gui/editInter.html
@@ -69,6 +69,12 @@
         </div>
       </div>
       <div class="form-group">
+        <label for="consumeKey" class="col-sm-2 control-label">Consumes Key?</label>
+        <div class="col-sm-10">
+          <input type="checkbox" th:field="*{consumeKey}" id="consumeKey" value="${consumeKey}" th:checked="${consumeKey}">
+        </div>
+      </div>
+      <div class="form-group">
         <label for="keyName" class="col-sm-2 control-label">Location (Room Name)</label>
         <div class="col-sm-10">
           <input type="text" th:field="*{roomName}" id="roomName" placeholder=*{roomName} class="col-4">

--- a/src/main/resources/templates/admin/gui/editNpc.html
+++ b/src/main/resources/templates/admin/gui/editNpc.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title> Resident Mystery </title>
+    <link rel="stylesheet" th:href="@{/css/bootstrap.min.css}" >
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link rel="stylesheet" th:href="@{https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css}">
+</head>
+<body>
+<div class="container-collector" id="main">
+    <div class="container-content" id="content_flex_top_collector">
+        <div class="col-6">
+
+        </div>
+
+        <div class="col-6 text-right">
+            Logged in user: <b th:inline="text"  class="user"> [[${#httpServletRequest.remoteUser}]] </b>
+            <form th:action="@{/app-logout}" method="POST" name="logoutForm">
+                <input type="submit" value="Logout"/>
+            </form>
+        </div>
+    </div>
+
+
+
+
+    <div class="container-content" id="content_flex_center">
+        <form action="#" th:action="@{/admin/updateNpc/{id}(id=${npc.id})}" th:object="${npc}" method="post" class="form-horizontal" style="width: 100%">
+            <div class="form-group">
+                <label for="npcName" class="col-sm-2 control-label">Name</label>
+                <div class="col-sm-10">
+                    <input type="text" th:field="*{npcName}" id="npcName" placeholder="npcName" class="col-4">
+                    <p class="text-danger" th:if="${#fields.hasErrors('npcName')}" th:errors="*{npcName}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="npcDesc" class="col-sm-2 control-label">Description</label>
+                <div class="col-sm-10">
+                    <textarea class="form-control" id="npcDesc" rows="20" th:field="*{npcDesc}"></textarea>
+                    <p class="text-danger" th:if="${#fields.hasErrors('npcDesc')}" th:errors="*{npcDesc}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="roomName" class="col-sm-2 control-label">Location (Room Name)</label>
+                <div class="col-sm-10">
+                    <input type="text" th:field="*{roomName}" id="roomName" placeholder="roomName" class="col-4">
+                    <p class="text-danger" th:if="${#fields.hasErrors('roomName')}" th:errors="*{roomName}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="canWander" class="col-sm-2 control-label">Can Wander?</label>
+                <div class="col-sm-10">
+                    <input type="checkbox" th:field="*{canWander}" id="canWander" value="${canWander}">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="wanderChance" class="col-sm-2 control-label">Chance to wander (0-100)</label>
+                <div class="col-sm-10">
+                    <input type="text" th:field="*{wanderChance}" id="wanderChance" placeholder="wanderChance" class="col-4">
+                    <p class="text-danger" th:if="${#fields.hasErrors('wanderChance')}" th:errors="*{wanderChance}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="firstInteraction" class="col-sm-2 control-label">First Interaction</label>
+                <div class="col-sm-10">
+                    <textarea class="form-control" id="firstInteraction" rows="5" th:field="*{firstInteraction}"></textarea>
+                    <p class="text-danger" th:if="${#fields.hasErrors('firstInteraction')}" th:errors="*{firstInteraction}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="repeatInteraction" class="col-sm-2 control-label">Repeat Interaction</label>
+                <div class="col-sm-10">
+                    <textarea class="form-control" id="repeatInteraction" rows="5" th:field="*{repeatInteraction}"></textarea>
+                    <p class="text-danger" th:if="${#fields.hasErrors('repeatInteraction')}" th:errors="*{repeatInteraction}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="solvingInteraction" class="col-sm-2 control-label">Solving Interaction</label>
+                <div class="col-sm-10">
+                    <textarea class="form-control" id="solvingInteraction" rows="5" th:field="*{solvingInteraction}"></textarea>
+                    <p class="text-danger" th:if="${#fields.hasErrors('solvingInteraction')}" th:errors="*{solvingInteraction}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="alreadySolvedInteraction" class="col-sm-2 control-label">Already Solved Interaction</label>
+                <div class="col-sm-10">
+                    <textarea class="form-control" id="alreadySolvedInteraction" rows="5" th:field="*{alreadySolvedInteraction}"></textarea>
+                    <p class="text-danger" th:if="${#fields.hasErrors('alreadySolvedInteraction')}" th:errors="*{alreadySolvedInteraction}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="rewardLoot" class="col-sm-2 control-label">Reward (Loot Name)</label>
+                <div class="col-sm-10">
+                    <input type="text" th:field="*{rewardLoot}" id="rewardLoot" placeholder="rewardLoot" class="col-4">
+                    <p class="text-danger" th:if="${#fields.hasErrors('rewardLoot')}" th:errors="*{rewardLoot}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="locked" class="col-sm-2 control-label">Has Quest/Locked?</label>
+                <div class="col-sm-10">
+                    <input type="checkbox" th:field="*{locked}" id="locked" value="${locked}">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="keyName" class="col-sm-2 control-label">Quest/Key Item (Loot Name)</label>
+                <div class="col-sm-10">
+                    <input type="text" th:field="*{keyName}" id="keyName" placeholder="keyName" class="col-4">
+                    <p class="text-danger" th:if="${#fields.hasErrors('rewardLoot')}" th:errors="*{keyName}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="consumeKey" class="col-sm-2 control-label">Consumes Key?</label>
+                <div class="col-sm-10">
+                    <input type="checkbox" th:field="*{consumeKey}" id="consumeKey" value="${consumeKey}" th:checked="${consumeKey}">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="gameEnd" class="col-sm-2 control-label">End Game When Solved?</label>
+                <div class="col-sm-10">
+                    <input type="checkbox" th:field="*{gameEnd}" id="gameEnd" value="${gameEnd}">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="endName" class="col-sm-2 control-label">Ending Name</label>
+                <div class="col-sm-10">
+                    <input type="text" th:field="*{endName}" id="endName" placeholder="endName" class="col-4">
+                    <p class="text-danger" th:if="${#fields.hasErrors('endName')}" th:errors="*{endName}"></p>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <div class="col-sm-12">
+                    <input type="hidden" th:field="*{id}">
+                    <a class="btn btn-danger btn-sm" href="/admin/manage">Cancel</a>
+                    <input class="btn btn-primary btn-sm" type="submit" value="Update Npc">
+                </div>
+            </div>
+
+        </form>
+    </div>
+
+    <div id="btmL">
+        <h2>Find me on social media</h2>
+        <h3><strong>A new project idea?</strong> Contact me!</h3>
+        <a href="https://twitter.com/Suracki" class="fa fa-twitter"></a>
+        <a href="https://github.com/Suracki" class="fa fa-github"></a>
+        <a href="https://www.linkedin.com/in/simon-linford/" class="fa fa-linkedin"></a>
+    </div>
+    <div id="btmR"></div>
+
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/manage.html
+++ b/src/main/resources/templates/admin/manage.html
@@ -163,6 +163,32 @@
                     </tbody>
                 </table>
             </th:block>
+            <th:block th:if="${type == 'all' or type == 'npc'}">
+                <h6>Npcs</h6>
+                <div class="form-group">
+                    <a href="/admin/addNpc" class="btn btn-primary btn-sm">Add New</a>
+                    <a href="/admin/filter?type=npc" class="btn btn-primary btn-sm">Filter</a>
+                </div>
+                <table class="table table-bordered">
+                    <thead>
+                    <tr>
+                        <th>Id</th>
+                        <th>Npc Name</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="npc : ${npcs}">
+                        <td style="width: 10%" th:text="${npc.id}"></td>
+                        <td th:text="${npc.npcName}"></td>
+                        <td style="width: 15%" class="text-center">
+                            <a th:href="@{/admin/updateNpc/{id}(id=${npc.id})}">Edit</a>&nbsp;|&nbsp;
+                            <a th:href="@{/admin/deleteNpc/{id}(id=${npc.id})}">Delete</a>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </th:block>
 
             <div class="alert alert-dark" role="alert">
                 <a th:href="@{/admin/export}"/>Export Current Game Data</a>

--- a/src/main/resources/templates/game/loot.html
+++ b/src/main/resources/templates/game/loot.html
@@ -27,11 +27,18 @@
 
     <div class="container-content" id="content_flex_center">
         <div class="form-group">
+            <th:block th:if="${npcName != null}">
+                <h6> <th:block th:text="${npcName}"></th:block></h6>
+                <p><th:block th:text="${npcSolvedText}"></th:block></p><br>
+                <p>From <th:block th:text="${npcName}"></th:block> you receive a <th:block th:text="${lootName}"></th:block></p>
+            </th:block>
+
             <th:block th:if="${interactableName != null}">
                 <h6> You examine the <th:block th:text="${interactableName}"></th:block></h6>
                 <p><th:block th:text="${interactableSolvedText}"></th:block></p><br>
                 <p>Within the <th:block th:text="${interactableName}"></th:block> you find a <th:block th:text="${lootName}"></th:block></p>
             </th:block>
+
             <h6> You examine the <th:block th:text="${lootName}"></th:block></h6>
             <p>
             <p><th:block th:text="${lootDescription}"></th:block></p>

--- a/src/main/resources/templates/game/room.html
+++ b/src/main/resources/templates/game/room.html
@@ -30,6 +30,14 @@
             <h6> <th:block th:text="${roomName}"></th:block></h6>
             <p>
                 <p><th:block th:text="${roomDesc}"></th:block></p>
+            <p><th:block th:if="${not #lists.isEmpty(npcs)}">
+                <br>Characters present:
+                <th:block th:each="npc :  ${npcs}">
+                    <a th:href="@{/game/speakWith/?npc={npc}(npc=${npc.npcName})}"/>
+                    <br><td th:text="${npc.npcName}"></td>
+                    </a>
+                </th:block>
+            </th:block></p>
                 <p><th:block th:if="${not #lists.isEmpty(interactables)}">
                     <br>In the room you see:
                     <th:block th:each="interactable :  ${interactables}">

--- a/src/main/resources/templates/game/speak.html
+++ b/src/main/resources/templates/game/speak.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title> Resident Mystery </title>
+    <link rel="stylesheet" th:href="@{/css/bootstrap.min.css}" >
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link rel="stylesheet" th:href="@{https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css}">
+</head>
+<body>
+<div class="container-collector" id="main">
+    <div class="container-content" id="content_flex_top_collector">
+        <div class="col-6">
+            <p><a class="btn btn-primary btn-sm col-xs-2" th:href="@{/game/restart}">Restart Game</a></p>
+            <p><th:block th:if="${admin != null}"><a class="btn btn-primary btn-sm col-xs-2" th:href="@{/admin/landing}">Admin Page</a></th:block></p>
+        </div>
+
+        <div class="col-6 text-right">
+            Logged in user: <b th:inline="text"  class="user"> [[${#httpServletRequest.remoteUser}]] </b>
+            <form th:action="@{/app-logout}" method="POST" name="logoutForm">
+                <input type="submit" value="Logout"/>
+            </form>
+        </div>
+    </div>
+
+
+
+
+    <div class="container-content" id="content_flex_center">
+        <div class="form-group">
+            <h6> <th:block th:text="${npcName}"></th:block></h6>
+            <p>
+            <p><th:block th:text="${npcDesc}"></th:block></p>
+
+            <th:block th:if="${not #strings.isEmpty(firstInter)}">
+                <th:block th:if="${lockstate == 'nokey'}">
+                    <p><th:block th:text="${firstInter}"></th:block></p>
+                    <div class="alert alert-warning" role="alert" th:if="${lockstate == 'nokey'}">
+                        It appears you do not currently have what they want.
+                    </div>
+                </th:block>
+                <th:block th:if="${lockstate == 'unlocking'}">
+                    <p><th:block th:text="${firstInter}"></th:block></p>
+                    <p><th:block th:text="${npcSolvedText}"></th:block></p>
+                </th:block>
+                <th:block th:if="${lockstate == 'notlocked'}">
+                    <th:block th:if="${not #strings.isEmpty(npcAlreadySolvedText)}">
+                        <p><th:block th:text="${npcAlreadySolvedText}"></th:block></p>
+                    </th:block>
+                    <th:block th:if="${#strings.isEmpty(npcAlreadySolvedText)}">
+                        <p><th:block th:text="${firstInter}"></th:block></p>
+                    </th:block>
+                </th:block>
+            </th:block>
+
+            <th:block th:if="${not #strings.isEmpty(repeatInter)}">
+                <th:block th:if="${lockstate == 'nokey'}">
+                    <p><th:block th:text="${repeatInter}"></th:block></p>
+                    <div class="alert alert-warning" role="alert" th:if="${lockstate == 'nokey'}">
+                        It appears you do not currently have what they want.
+                    </div>
+                </th:block>
+                <th:block th:if="${lockstate == 'unlocking'}">
+                    <p><th:block th:text="${npcSolvedText}"></th:block></p>
+                </th:block>
+                <th:block th:if="${lockstate == 'notlocked'}">
+                    <th:block th:if="${not #strings.isEmpty(npcAlreadySolvedText)}">
+                        <p><th:block th:text="${npcAlreadySolvedText}"></th:block></p>
+                    </th:block>
+                    <th:block th:if="${#strings.isEmpty(npcAlreadySolvedText)}">
+                        <p><th:block th:text="${repeatInter}"></th:block></p>
+                    </th:block>
+                </th:block>
+            </th:block>
+            <p>
+                <a th:href="@{/game/start/}"/>
+                Return to <td th:text="${roomName}"></td>
+            </a>
+            </p>
+        </div>
+    </div>
+
+    <div id="btmL">
+        <h2>Find me on social media</h2>
+        <h3><strong>A new project idea?</strong> Contact me!</h3>
+        <a href="https://twitter.com/Suracki" class="fa fa-twitter"></a>
+        <a href="https://github.com/Suracki" class="fa fa-github"></a>
+        <a href="https://www.linkedin.com/in/simon-linford/" class="fa fa-linkedin"></a>
+    </div>
+    <div id="btmR"></div>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
NPCs added.

- Ability to add/edit/remove via admin pages
- NPCs can be 'locked' (quests), which are solved by providing key items
-- Key items can now optionally be consumed when completing quests/unlocking interactables
- NPCs can be set to wander, and will automatically check for and use unlocked exits